### PR TITLE
feat: add regression

### DIFF
--- a/mensura/v_info/regression.py
+++ b/mensura/v_info/regression.py
@@ -28,7 +28,7 @@ def ridge_regression(
             Must be between 0 and 1. Defaults to 0.2.
         random_state (int, optional): Random seed for reproducibility. Defaults to 0.
         alpha (float, optional): Regularization strength for Ridge when `use_cv` is False.
-            Must be a positive float. Defaults to 1.0.
+            Must be a positive float. Defaults to 100.0.
         use_cv (bool, optional): Whether to perform cross-validated ridge regression
             using `RidgeCV`. If True, the `alpha` parameter is ignored. Defaults to False.
         cv_folds (int, optional): Number of folds for cross-validation when `use_cv` is True.

--- a/mensura/v_info/regression.py
+++ b/mensura/v_info/regression.py
@@ -1,0 +1,65 @@
+import numpy as np
+from sklearn.linear_model import Ridge, RidgeCV
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+
+def ridge_regression(
+    x: np.ndarray,
+    y: np.ndarray,
+    test_size: float = 0.2,
+    random_state: int = 0,
+    alpha: float = 100.0,
+    use_cv: bool = False,
+    cv_folds: int = 5,
+) -> float:
+    """Fit a Ridge regression model with optional cross-validation and return the R^2 score.
+
+    This function splits the data into training and test sets, fits either Ridge or RidgeCV
+    (using the provided `alphas` grid, or a default logarithmic grid), and computes the
+    variance-weighted R² score on the held-out test set.
+
+    Args:
+        x (np.ndarray): Feature matrix of shape (n_samples, n_features).
+        y (np.ndarray): Target array of shape (n_samples,) or (n_samples, n_targets).
+        test_size (float, optional): Proportion of the dataset to include in the test split.
+            Must be between 0 and 1. Defaults to 0.2.
+        random_state (int, optional): Random seed for reproducibility. Defaults to 0.
+        alpha (float, optional): Regularization strength for Ridge when `use_cv` is False.
+            Must be a positive float. Defaults to 1.0.
+        use_cv (bool, optional): Whether to perform cross-validated ridge regression
+            using `RidgeCV`. If True, the `alpha` parameter is ignored. Defaults to False.
+        cv_folds (int, optional): Number of folds for cross-validation when `use_cv` is True.
+            Defaults to 5.
+
+    Returns:
+        float: The R² score (variance-weighted) computed on the test set.
+    """
+    # split data into training and test sets
+    x_train, x_test, y_train, y_test = train_test_split(
+        x, y, test_size=test_size, random_state=random_state
+    )
+
+    # select model
+    if use_cv:
+        model = Pipeline([
+            ('scaler', StandardScaler()),
+            ('ridge_cv', RidgeCV(alphas=np.logspace(-3, 4, 50), cv=cv_folds, fit_intercept=True)),
+        ])
+    else:
+        model = Pipeline([
+            ('scaler', StandardScaler()),
+            ('ridge', Ridge(alpha=alpha, fit_intercept=True)),
+        ])
+
+    # train model
+    model.fit(x_train, y_train)
+    # evaluate model
+    score = r2_score(
+        y_test,
+        model.predict(x_test),
+        multioutput="variance_weighted"
+    )
+    return score

--- a/scripts/compute_r2.py
+++ b/scripts/compute_r2.py
@@ -15,6 +15,8 @@ from torchvision.datasets import ImageFolder
 from torchvision.models.feature_extraction import create_feature_extractor
 from tqdm.contrib import tenumerate
 
+from mensura.v_info.regression import ridge_regression
+
 if __name__ == "__main__":
     import argparse
 
@@ -91,25 +93,29 @@ if __name__ == "__main__":
     feat3_np = feat3.numpy()
     feat_gp_np = feat_gp.numpy()
 
-    z_index = 100
-    x_train, x_test, y_train, y_test = train_test_split(feat3_np, feat_gp_np[:, z_index], test_size=0.2, random_state=0)
+    # z_index = 100
+    # x_train, x_test, y_train, y_test = train_test_split(feat3_np, feat_gp_np[:, z_index], test_size=0.2, random_state=0)
 
-    print("x_train.shape", x_train.shape)
-    print("x_test.shape", x_test.shape)
-    print("y_train.shape", y_train.shape)
-    print("y_test.shape", y_test.shape)
+    # print("x_train.shape", x_train.shape)
+    # print("x_test.shape", x_test.shape)
+    # print("y_train.shape", y_train.shape)
+    # print("y_test.shape", y_test.shape)
+
+    # print("Fitting Ridge regression...")
+    # if False:
+    #     # Use RidgeCV to find the best alpha
+    #     alphas = np.logspace(-3, 4, 50) # 1e-3 ~ 1e4
+    #     reg = make_pipeline(StandardScaler(with_mean=True), RidgeCV(alphas=alphas, cv=5, fit_intercept=True))
+    #     reg.fit(x_train, y_train)
+    #     print("best alpha =", reg[-1].alpha_)
+    # else:
+    #     # Use a fixed alpha
+    #     reg = make_pipeline(StandardScaler(with_mean=True), Ridge(alpha=args.ridge_alpha, fit_intercept=True))
+    #     reg.fit(x_train, y_train)
+
+    # r2 = r2_score(y_test, reg.predict(x_test), multioutput="variance_weighted")
 
     print("Fitting Ridge regression...")
-    if False:
-        # Use RidgeCV to find the best alpha
-        alphas = np.logspace(-3, 4, 50) # 1e-3 ~ 1e4
-        reg = make_pipeline(StandardScaler(with_mean=True), RidgeCV(alphas=alphas, cv=5, fit_intercept=True))
-        reg.fit(x_train, y_train)
-        print("best alpha =", reg[-1].alpha_)
-    else:
-        # Use a fixed alpha
-        reg = make_pipeline(StandardScaler(with_mean=True), Ridge(alpha=args.ridge_alpha, fit_intercept=True))
-        reg.fit(x_train, y_train)
-
-    r2 = r2_score(y_test, reg.predict(x_test), multioutput="variance_weighted")
+    z_index = 100
+    r2 = ridge_regression(feat3_np, feat_gp_np[:, z_index])
     print(f"R^2 = {r2:.4f}")

--- a/tests/mensura/v_info/test_regression.py
+++ b/tests/mensura/v_info/test_regression.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from mensura.v_info.regression import ridge_regression
+
+
+def test_perfect_linear_relation() -> None:
+    """Test perfect linear data yields R² of 1.0 when no regularization is used.
+
+    Creates y = 3x + 1 exactly and calls ridge_regression with alpha=0.0
+    (ordinary least squares). Asserts that the computed R² equals 1.0 within
+    floating-point tolerance.
+    """
+    x: np.ndarray = np.linspace(0, 1, 100).reshape(-1, 1)
+    y: np.ndarray = 3 * x.flatten() + 1
+    score: float = ridge_regression(
+        x, y, test_size=0.2, random_state=42, alpha=0.0
+    )
+    assert score == pytest.approx(1.0, rel=1e-6)  # rel tolerance handles FP error
+
+
+def test_use_cv_reproducibility() -> None:
+    """Test that enabling cross-validation produces reproducible results.
+
+    With the same random_state and data, calling
+    ridge_regression twice with use_cv=True should yield identical scores.
+    """
+    rng = np.random.RandomState(0)
+    x: np.ndarray = rng.randn(100, 1)
+    y: np.ndarray = 2 * x.flatten() + rng.randn(100) * 1e-6
+    score1: float = ridge_regression(
+        x, y, test_size=0.2, random_state=0, use_cv=True, cv_folds=3
+    )
+    score2: float = ridge_regression(
+        x, y, test_size=0.2, random_state=0, use_cv=True, cv_folds=3
+    )
+    assert score1 == pytest.approx(score2)
+
+
+def test_default_parameters_run() -> None:
+    """Test that the function runs with default parameters and returns a float.
+
+    Ensures that, when using defaults, the returned R² is within [-1, 1].
+    """
+    rng = np.random.RandomState(1)
+    x: np.ndarray = rng.randn(50, 5)
+    y: np.ndarray = x.dot(np.arange(5)) + rng.randn(50) * 1e-3
+    score: float = ridge_regression(x, y)
+    assert isinstance(score, float)
+    assert -1.0 <= score <= 1.0
+
+
+def test_invalid_shapes_raises_value_error() -> None:
+    """Test that mismatched sample sizes between x and y raise ValueError.
+
+    Passing x with 10 samples and y with 11 should trigger train_test_split error.
+    """
+    x: np.ndarray = np.zeros((10, 2))
+    y: np.ndarray = np.zeros(11)
+    with pytest.raises(ValueError):
+        ridge_regression(x, y)
+
+
+def test_invalid_test_size_raises_value_error() -> None:
+    """Test that out-of-range test_size values raise ValueError.
+
+    A test_size >1.0 or <0.0 should be invalid.
+    """
+    x: np.ndarray = np.zeros((10, 2))
+    y: np.ndarray = np.zeros(10)
+    with pytest.raises(ValueError):
+        ridge_regression(x, y, test_size=1.5)


### PR DESCRIPTION
This pull request introduces a new `ridge_regression` function in `mensura/v_info/regression.py` to streamline Ridge regression tasks, refactors existing code in `scripts/compute_r2.py` to use this function, and adds comprehensive unit tests for the new functionality. The changes improve code modularity, reusability, and test coverage.

### New functionality:
* Added `ridge_regression` function in `mensura/v_info/regression.py` to perform Ridge regression with optional cross-validation, returning the R² score. It supports configurable parameters such as `alpha`, `test_size`, and `cv_folds`.

### Code refactoring:
* Refactored `scripts/compute_r2.py` to replace inline Ridge regression logic with a call to the new `ridge_regression` function, simplifying the script and removing redundant code. [[1]](diffhunk://#diff-bab9e303c2cffa6fdd01b9953b21bcdf0b3db622fbeb72d6834c92a6d998a4baR18-R19) [[2]](diffhunk://#diff-bab9e303c2cffa6fdd01b9953b21bcdf0b3db622fbeb72d6834c92a6d998a4baL94-R120)

### Testing improvements:
* Added unit tests in `tests/mensura/v_info/test_regression.py` to validate the behavior of `ridge_regression`. Tests cover perfect linear relationships, reproducibility with cross-validation, default parameter execution, and error handling for invalid input shapes or `test_size` values.## Issue URL