### PR TITLE
Feat/add complexity measure

### DIFF
--- a/mensura/v_info/complexity_measure.py
+++ b/mensura/v_info/complexity_measure.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+from typing import OrderedDict as TypingOrderedDict
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class VInformation:
+    """Stores V-information metrics for a single feature.
+
+    Attributes:
+        var_z (float): Variance of the feature z.
+        r2 (float): Coefficient of determination (R²) for the feature.
+        value (float): Computed V-information value (var_z * r2).
+    """
+    var_z: float
+    r2: float
+    value: float = field(init=False)
+
+    def __post_init__(self):
+        """Post-initialization to compute the combined V-information value."""
+        object.__setattr__(self, "value", self.var_z * self.r2)
+
+@dataclass(frozen=True)
+class ComplexityMeasureK:
+    """Calculates the complexity measure K for a set of V-information values.
+
+    Attributes:
+        v_infos (OrderedDict[str, VInformation]): Mapping from feature keys
+            to their V-information objects.
+        value (float): Computed complexity measure K = 1 - mean(V-information values).
+    """
+    v_infos: TypingOrderedDict[str, VInformation]
+    value: float = field(init=False)
+
+    def __post_init__(self):
+        """Post-initialization to compute the complexity value K from V-information."""
+        mean_v_info = float(np.mean([vi.value for vi in self.v_infos.values()]))
+        object.__setattr__(self, "value", 1.0 - mean_v_info)

--- a/scripts/compute_r2.py
+++ b/scripts/compute_r2.py
@@ -54,5 +54,12 @@ if __name__ == "__main__":
 
     print("Fitting Ridge regression...")
     z_index = 100
-    r2 = ridge_regression(feat3_np, feat_gp_np[:, z_index])
+    z = feat_gp_np[:, z_index]
+    r2 = ridge_regression(feat3_np, z)
     print(f"R^2 = {r2:.4f}")
+
+    var_z = float(np.var(z, ddof=0))
+    print(f"Var(z) = {var_z:.4f}")
+
+    v_info = var_z * r2
+    print(f"v-information = {v_info:.4f}")

--- a/tests/mensura/v_info/test_complexity_measure.py
+++ b/tests/mensura/v_info/test_complexity_measure.py
@@ -1,0 +1,65 @@
+import dataclasses
+import math
+from collections import OrderedDict
+from typing import OrderedDict as TypingOrderedDict
+
+import pytest
+
+from mensura.v_info.complexity_measure import ComplexityMeasureK, VInformation
+
+
+def test_vinformation_computation() -> None:
+    """Test that VInformation computes `value = var_z * r2` correctly."""
+    vi = VInformation(var_z=3.0, r2=0.2)
+    expected_value: float = 3.0 * 0.2
+    assert vi.value == pytest.approx(expected_value), "VInformation.value should be var_z * r2"
+
+def test_vinformation_is_frozen() -> None:
+    """Test that VInformation is immutable (frozen dataclass).
+    Attempting to set an attribute should raise FrozenInstanceError.
+    """
+    vi = VInformation(var_z=1.5, r2=0.5)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        vi.var_z = 2.0  # type: ignore
+
+@pytest.mark.parametrize(
+    ("r2_values", "expected_mean_r2"),
+    [
+        ([0.0, 1.0], 0.5),
+        ([0.25, 0.75, 0.5], (0.25 + 0.75 + 0.5) / 3),
+        ([1.0, 1.0, 1.0], 1.0),
+    ],
+)
+def test_complexity_measure_k_computation(
+    r2_values: list[float],
+    expected_mean_r2: float,
+) -> None:
+    """Test that ComplexityMeasureK computes `value = 1.0 - mean(VInformation.value)`
+    correctly when var_z == 1 for all entries.
+    """
+    # Build an OrderedDict[str, VInformation] where var_z=1.0 so value == r2
+    v_infos: TypingOrderedDict[str, VInformation] = OrderedDict(
+        (f"feat{i}", VInformation(var_z=1.0, r2=r2))
+        for i, r2 in enumerate(r2_values)
+    )
+    cm = ComplexityMeasureK(v_infos=v_infos)
+    assert cm.value == pytest.approx(1.0 - expected_mean_r2), (
+        "ComplexityMeasureK.value should equal 1 - mean of VInformation.value"
+    )
+
+def test_complexity_measure_k_empty_dict_results_in_nan() -> None:
+    """Test that passing an empty OrderedDict yields cm.value == nan (no exception)."""
+    empty: TypingOrderedDict[str, VInformation] = OrderedDict()
+    cm = ComplexityMeasureK(v_infos=empty)
+    assert math.isnan(cm.value), "ComplexityMeasureK.value should be nan for empty input"
+
+def test_complexity_measure_k_is_frozen() -> None:
+    """Test that ComplexityMeasureK is immutable (frozen dataclass).
+    Attempting to set its `value` should raise FrozenInstanceError.
+    """
+    single: TypingOrderedDict[str, VInformation] = OrderedDict(
+        {"only": VInformation(var_z=2.0, r2=0.3)}
+    )
+    cm = ComplexityMeasureK(v_infos=single)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cm.value = 0.0  # type: ignore


### PR DESCRIPTION
This pull request introduces a new feature for computing and testing V-information metrics and complexity measures. It adds two frozen dataclasses, `VInformation` and `ComplexityMeasureK`, for encapsulating these computations, updates an existing script to calculate and display V-information, and includes comprehensive unit tests to ensure correctness and immutability of the new classes.

### New feature: V-information and complexity measure

* `mensura/v_info/complexity_measure.py`: Added two frozen dataclasses:
  - [`VInformation`](diffhunk://#diff-34845c6f7338599c0c7eb3d4b8e435ba0e35daf64b5bb27685c1edfe34f209bfR1-R39): Represents V-information metrics for a single feature, with attributes `var_z`, `r2`, and a computed `value` (var_z * r2). ([mensura/v_info/complexity_measure.pyR1-R39](diffhunk://#diff-34845c6f7338599c0c7eb3d4b8e435ba0e35daf64b5bb27685c1edfe34f209bfR1-R39))
  - [`ComplexityMeasureK`](diffhunk://#diff-34845c6f7338599c0c7eb3d4b8e435ba0e35daf64b5bb27685c1edfe34f209bfR1-R39): Represents the complexity measure K, computed as `1 - mean(V-information values)` from an ordered dictionary of `VInformation` objects. ([mensura/v_info/complexity_measure.pyR1-R39](diffhunk://#diff-34845c6f7338599c0c7eb3d4b8e435ba0e35daf64b5bb27685c1edfe34f209bfR1-R39))

### Script enhancement: V-information computation

* [`scripts/compute_r2.py`](diffhunk://#diff-bab9e303c2cffa6fdd01b9953b21bcdf0b3db622fbeb72d6834c92a6d998a4baL57-R65): Updated the script to compute and display the variance (`var_z`) of a feature and its V-information value (`var_z * r2`) after calculating R². ([scripts/compute_r2.pyL57-R65](diffhunk://#diff-bab9e303c2cffa6fdd01b9953b21bcdf0b3db622fbeb72d6834c92a6d998a4baL57-R65))

### Unit tests: Validation of new functionality

* `tests/mensura/v_info/test_complexity_measure.py`: Added unit tests to validate the correctness and immutability of `VInformation` and `ComplexityMeasureK`:
  - Verified that `value` is computed correctly for both classes. ([tests/mensura/v_info/test_complexity_measure.pyR1-R65](diffhunk://#diff-8c27737b0a75f65955168424346508a34e8fecd2a1af2e68ae888ea59dd121d7R1-R65))
  - Ensured immutability by testing for `FrozenInstanceError` when attempting to modify attributes. ([tests/mensura/v_info/test_complexity_measure.pyR1-R65](diffhunk://#diff-8c27737b0a75f65955168424346508a34e8fecd2a1af2e68ae888ea59dd121d7R1-R65))
  - Tested edge cases, such as `ComplexityMeasureK` handling an empty dictionary, resulting in `NaN`. ([tests/mensura/v_info/test_complexity_measure.pyR1-R65](diffhunk://#diff-8c27737b0a75f65955168424346508a34e8fecd2a1af2e68ae888ea59dd121d7R1-R65))
