### PR TITLE
feat: save args and data as JSON file

### DIFF
--- a/scripts/compute_complexity_measure.py
+++ b/scripts/compute_complexity_measure.py
@@ -74,8 +74,8 @@ if __name__ == "__main__":
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
     # dump arguments
-    argments_output_path = output_dir_path / "args.json"
-    with argments_output_path.open("w", encoding="utf-8") as f:
+    arguments_output_path = output_dir_path / "args.json"
+    with arguments_output_path.open("w", encoding="utf-8") as f:
         json.dump(vars(args), f, indent=4, default=path_converter)
 
     # prepare backbone

--- a/scripts/compute_complexity_measure.py
+++ b/scripts/compute_complexity_measure.py
@@ -1,5 +1,8 @@
+import json
 import pathlib
 from collections import OrderedDict
+from dataclasses import asdict
+from datetime import datetime
 
 import numpy as np
 import torch
@@ -10,6 +13,27 @@ from tqdm import tqdm
 from mensura.v_info.complexity_measure import ComplexityMeasureK, VInformation
 from mensura.v_info.feature import build_feature_extractor, extract_features
 from mensura.v_info.regression import ridge_regression
+
+
+def path_converter(obj: object) -> str:
+    """JSON serializer for `pathlib.Path` objects.
+
+    Converts a `Path` object to its string representation so that it
+    can be serialized by the standard `json` module.
+
+    Args:
+        obj (object): The object to serialize. Expected to be a `Path`.
+
+    Returns:
+        str: The string representation of the `Path`.
+
+    Raises:
+        TypeError: If `obj` is not an instance of `pathlib.Path`.
+    """
+    if isinstance(obj, pathlib.Path):
+        return str(obj)
+    raise TypeError(f"{obj!r} is not JSON serializable")
+
 
 if __name__ == "__main__":
     import argparse
@@ -24,6 +48,12 @@ if __name__ == "__main__":
         default="stages.0,stages.1,stages.2,stages.3,head.global_pool",
         help="Comma separated list of FX graph node names.",
     )
+    p.add_argument("--weights-path", type=pathlib.Path, default=None)
+    p.add_argument(
+        "--output-dir-path",
+        type=pathlib.Path,
+        default=pathlib.Path("outputs/compute_complexity_measure"),
+    )
     p.add_argument("--device", default="cuda")
     p.add_argument("--num-samples", type=int, default=10000)
     p.add_argument("--batch-size", type=int, default=256)
@@ -32,6 +62,22 @@ if __name__ == "__main__":
 
     device = torch.device(args.device)
 
+    # create output directory
+    now = datetime.now()
+    ts = now.strftime("%Y%m%d_%H%M%S")
+    dir_name = (
+        f"{ts}_model={args.model_name}_weights={str(args.weights_path)}"
+        if args.weights_path
+        else f"{ts}_model={args.model_name}"
+    )
+    output_dir_path = args.output_dir_path / dir_name
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+
+    # dump arguments
+    argments_output_path = output_dir_path / "args.json"
+    with argments_output_path.open("w", encoding="utf-8") as f:
+        json.dump(vars(args), f, indent=4, default=path_converter)
+
     # prepare backbone
     print(f"Loading model {args.model_name}...")
     node_keys = args.nodes.split(",")
@@ -39,6 +85,7 @@ if __name__ == "__main__":
         model_name=args.model_name,
         node_keys=node_keys,
         device=device,
+        weights_path=args.weights_path,
     )
 
     # prepare datasets
@@ -61,6 +108,7 @@ if __name__ == "__main__":
     z_all = features["head_global_pool"].numpy()
 
     # compute complexity measure K
+    complexity_mesure_output_path = output_dir_path / "complexity_measure.jsonl"
     with tqdm(enumerate(z_all.T), total=z_all.shape[1]) as pbar:
         for i, z in pbar:
             v_infos = OrderedDict()
@@ -72,4 +120,14 @@ if __name__ == "__main__":
             complexity_measure_k = ComplexityMeasureK(v_infos)
             pbar.set_postfix(complexity_measure_k=f"{complexity_measure_k.value:.4f}")
             print(f"Complexity measure K of z_{i} = {complexity_measure_k.value:.4f}")
-            print(complexity_measure_k)
+
+            with complexity_mesure_output_path.open("a", encoding="utf-8") as f:
+                out_dict = {
+                    "z_index": i,
+                    "complexity_mesure": asdict(complexity_measure_k),
+                }
+                json.dump(out_dict, f, indent=4)
+                f.write("\n")
+
+            if i >= 10:
+                break

--- a/scripts/compute_complexity_measure.py
+++ b/scripts/compute_complexity_measure.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     z_all = features["head_global_pool"].numpy()
 
     # compute complexity measure K
-    complexity_mesure_output_path = output_dir_path / "complexity_measure.jsonl"
+    complexity_measure_output_path = output_dir_path / "complexity_measure.jsonl"
     with tqdm(enumerate(z_all.T), total=z_all.shape[1]) as pbar:
         for i, z in pbar:
             v_infos = OrderedDict()

--- a/scripts/compute_complexity_measure.py
+++ b/scripts/compute_complexity_measure.py
@@ -121,10 +121,10 @@ if __name__ == "__main__":
             pbar.set_postfix(complexity_measure_k=f"{complexity_measure_k.value:.4f}")
             print(f"Complexity measure K of z_{i} = {complexity_measure_k.value:.4f}")
 
-            with complexity_mesure_output_path.open("a", encoding="utf-8") as f:
+            with complexity_measure_output_path.open("a", encoding="utf-8") as f:
                 out_dict = {
                     "z_index": i,
-                    "complexity_mesure": asdict(complexity_measure_k),
+                    "complexity_measure": asdict(complexity_measure_k),
                 }
                 json.dump(out_dict, f, indent=4)
                 f.write("\n")


### PR DESCRIPTION
This pull request enhances the `compute_complexity_measure.py` script by introducing new functionality for output management, improving JSON serialization, and adding support for additional arguments. The most important changes include adding a custom JSON serializer, implementing output directory creation and argument dumping, and enabling the script to save complexity measures to a file.

### New functionality for output management:

* Added functionality to create an output directory based on the current timestamp, model name, and weights path. The directory is used to store output files such as arguments and complexity measures. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyR65-R88](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8R65-R88))
* Implemented saving of complexity measures to a JSONL file (`complexity_measure.jsonl`) in the output directory. Each entry includes the index and serialized complexity measure data. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyL75-R133](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8L75-R133))

### JSON serialization improvements:

* Introduced a `path_converter` function to serialize `pathlib.Path` objects into strings for JSON dumping. This ensures compatibility with the standard JSON module. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyR17-R37](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8R17-R37))

### Additional argument support:

* Added `--weights-path` and `--output-dir-path` arguments to the script. These allow users to specify a model weights file and customize the output directory path, respectively. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyR51-R56](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8R51-R56))