### PR TITLE
[WIP]Feat/update compute complexity measure.py

### DIFF
--- a/mensura/v_info/feature.py
+++ b/mensura/v_info/feature.py
@@ -40,12 +40,15 @@ def build_feature_extractor(
     """
     # Initialize backbone (load custom checkpoint if provided)
     if weights_path is not None:
+        print(f"Loading custom weights from {weights_path}...")
         backbone = timm.create_model(
             model_name,
             pretrained=False,
+            num_classes=1000,
             checkpoint_path=str(weights_path),
         )
     else:
+        print(f"Loading pretrained weights for {model_name}...")
         backbone = timm.create_model(model_name, pretrained=True)
 
     backbone = backbone.eval().to(device)
@@ -59,8 +62,16 @@ def build_feature_extractor(
     )
 
     # Create evaluation transform
-    config = resolve_data_config({}, model=backbone)  # type: ignore[no-untyped-call]
-    transform = create_transform(**config)
+    # config = resolve_data_config({}, model=backbone)  # type: ignore[no-untyped-call]
+    # transform = create_transform(**config)
+    import torchvision.transforms as transforms
+
+    transform = transforms.Compose([
+        transforms.Resize(256, interpolation=2),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
+        ])
 
     return feature_extractor, transform
 
@@ -141,6 +152,11 @@ def extract_features(
     for key in node_keys:
         feat0 = _flatten_feature(sample_out[key])
         buffers[key] = torch.empty((sample_limit, feat0.size(1)), dtype=feat0.dtype)
+        if key == "layer4":
+            # 生テンソルのshapeでバッファ作るぞ！
+            raw_layer4_buffer = torch.empty(
+                (sample_limit, *sample_out[key].shape[1:]), dtype=sample_out[key].dtype
+            )
 
     # Fill buffers
     # NOTE: total_samples is a needed for the case drop_last=False
@@ -160,6 +176,12 @@ def extract_features(
             for key in node_keys:
                 flattened = _flatten_feature(out[key]).cpu()
                 buffers[key][start:end] = flattened
+                if key == "layer4" and raw_layer4_buffer is not None:
+                    # flattenせずに生テンソルも保存！
+                    raw_layer4_buffer[start:end] = out[key].cpu()
             total_samples = end  # update running total
+    # layer4の生テンソルも返す
+    if raw_layer4_buffer is not None:
+        buffers["layer4_raw"] = raw_layer4_buffer
 
     return buffers

--- a/scripts/compute_complexity_measure.py
+++ b/scripts/compute_complexity_measure.py
@@ -45,7 +45,8 @@ if __name__ == "__main__":
     p.add_argument("--model-name", default="resnetv2_50x1_bit.goog_distilled_in1k")
     p.add_argument(
         "--nodes",
-        default="stages.0,stages.1,stages.2,stages.3,head.global_pool",
+        # default="stages.0,stages.1,stages.2,stages.3,head.global_pool",
+        default="layer1,layer2,layer3,layer4,global_pool",
         help="Comma separated list of FX graph node names.",
     )
     p.add_argument("--weights-path", type=pathlib.Path, default=None)
@@ -90,7 +91,17 @@ if __name__ == "__main__":
     )
 
     # prepare datasets
+    # import torchvision
+    # if args.dataset_dir_path == pathlib.Path("CIFAR10"):
+    # print("Loading CIFAR100 dataset...")
+    # dataset = torchvision.datasets.CIFAR100(
+    #     root="./data",
+    #     train=False,
+    #     download=True,
+    #     transform=transform
+    # )
     dataset = ImageFolder(root=args.dataset_dir_path, transform=transform)
+    print("dataset:", dataset)
     subset = Subset(dataset, torch.randperm(len(dataset))[: args.num_samples])
     loader = DataLoader(
         subset,
@@ -104,8 +115,108 @@ if __name__ == "__main__":
 
     print("Extracting features...")
     features = extract_features(feature_extractor, loader, args.num_samples, device)
-    features_np = {k: v.numpy() for k, v in features.items() if k != "head_global_pool"}
-    z_all = features["head_global_pool"].numpy()
+    features_np = {k: v.numpy() for k, v in features.items() if k not in ("global_pool", "layer4_raw")}
+    z_all = features["global_pool"].numpy()
+    penultimate = features["layer4_raw"].numpy()
+    print(f"penultimate.shape: {penultimate.shape}")
+
+    # # 空間相関ρ̂を推定して動的係数aを計算
+    # N, C, H, W = penultimate.shape
+    # penultimate_flat = penultimate.reshape(N, C, H * W)  # [N, 2048, 49]
+    # # 各チャネルごとに相関係数を計算
+    # rho_list = []
+    # iu = np.triu_indices(H*W, k=1)
+    # for c in range(C):
+    #     # サンプル軸でセンタリング
+    #     x = penultimate_flat[:, c, :]                     # [N,49]
+    #     # 各サンプルごとに平均を引く
+    #     x_centered = x - x.mean(axis=0, keepdims=True)
+    #     # 列（空間ピクセル位置）ごとの相関行列
+    #     corr = np.corrcoef(x_centered, rowvar=False)  # (49,49)
+
+    #     # 上三角のオフダイアゴナル要素を抽出して NaN を除去
+    #     vals = corr[iu]
+    #     vals = vals[np.isfinite(vals)]
+    #     if vals.size > 0:
+    #         rho_list.append(vals.mean())
+    #     # rho_list.append(corr[iu].mean())
+    # rho_hat = np.mean(rho_list)
+
+    # # もし 1 チャネルも計算できなかったら 0 にフォールバック
+    # if len(rho_list) == 0:
+    #     rho_hat = 0.0
+    # else:
+    #     rho_hat = float(np.mean(rho_list))
+
+    # with np.errstate(invalid='ignore', divide='ignore'):
+    #     a = np.sqrt(H*W / (1 + (H*W - 1) * rho_hat))
+    # print(f"rho_hat={rho_hat:.4f}, a={a:.4f}🚀")
+
+    # # NaN になっていないか念のためチェックしてからスケール
+    # if np.isfinite(a):
+    #     z_all = z_all * a
+    # else:
+    #     # 異常時はスケールしない or デフォルト値を使う
+    #     print("Warning: computed 'a' is NaN or Inf; skipping rescale.")
+
+    # # rho_hatとaをargs.jsonに追記するぞ！
+    # with arguments_output_path.open("r", encoding="utf-8") as f:
+    #     args_dict = json.load(f)
+    # args_dict["rho_hat"] = float(rho_hat)
+    # args_dict["dynamic_coefficient_a"] = float(a)
+    # with arguments_output_path.open("w", encoding="utf-8") as f:
+    #     json.dump(args_dict, f, indent=4, default=path_converter)
+
+    ########################################################################実験中
+    # 空間相関 ρ をチャンネルごとに推定して動的係数 a_c を計算
+    # N, C, H, W = penultimate.shape
+    # penultimate_flat = penultimate.reshape(N, C, H * W)  # [N, C, H*W]
+    # iu = np.triu_indices(H * W, k=1)
+
+    # rho_per_channel = []
+    # for c in range(C):
+    #     x = penultimate_flat[:, c, :]                   # [N, H*W]
+    #     # 各ピクセル位置でセンタリング
+    #     x_centered = x - x.mean(axis=0, keepdims=True)  # [N, H*W]
+
+    #     # ① 列ごとの標準偏差を計算し、ほぼゼロ分散列を除外
+    #     std = x_centered.std(axis=0, ddof=0)            # [H*W]
+    #     valid_cols = std > 1e-6                         # 閾値は適宜調整
+    #     if valid_cols.sum() < 2:
+    #         # 有効な列が少なすぎると相関が取れないので ρ=0 にフォールバック
+    #         rho_per_channel.append(0.0)
+    #         continue
+
+    #     x_valid = x_centered[:, valid_cols]             # [N, #valid]
+    #     corr = np.corrcoef(x_valid, rowvar=False)       # (#valid, #valid)
+
+    #     vals = corr[np.triu_indices(corr.shape[0], k=1)]
+    #     vals = vals[np.isfinite(vals)]
+    #     rho_per_channel.append(vals.mean() if vals.size > 0 else 0.0)
+
+    # rho_per_channel = np.array(rho_per_channel, dtype=float)  # shape [C]
+
+    # # 各チャンネルに対応する a_c を計算
+    # with np.errstate(invalid='ignore', divide='ignore'):
+    #     a_per_channel = np.sqrt((H * W) / (1 + (H * W - 1) * rho_per_channel))  # shape [C]
+
+    # # NaN／Inf を 1 にフォールバック
+    # a_per_channel = np.where(np.isfinite(a_per_channel), a_per_channel, 1.0)
+
+    # print(f"mean rho: {rho_per_channel.mean():.4f}, a per channel sample: {a_per_channel[:5]}")
+    # # z_all にチャンネルごとのスケーリングを適用
+    # z_all = z_all * a_per_channel[None, :]
+
+    # # args.json にも rho_per_channel と a_per_channel の統計を追記
+    # with arguments_output_path.open("r", encoding="utf-8") as f:
+    #     args_dict = json.load(f)
+    # args_dict["rho_mean"] = float(rho_per_channel.mean())
+    # args_dict["a_mean"]   = float(a_per_channel.mean())
+    # with arguments_output_path.open("w", encoding="utf-8") as f:
+    #     json.dump(args_dict, f, indent=4, default=path_converter)
+
+
+    #########################################################################
 
     # compute complexity measure K
     complexity_measure_output_path = output_dir_path / "complexity_measure.jsonl"

--- a/scripts/compute_complexity_measure_49.py
+++ b/scripts/compute_complexity_measure_49.py
@@ -1,0 +1,172 @@
+import json
+import pathlib
+from collections import OrderedDict
+from dataclasses import asdict
+from datetime import datetime
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Subset
+from torchvision.datasets import ImageFolder
+from tqdm import tqdm
+
+from mensura.v_info.complexity_measure import ComplexityMeasureK, VInformation
+from mensura.v_info.feature import build_feature_extractor, extract_features
+from mensura.v_info.regression import ridge_regression
+
+
+def path_converter(obj: object) -> str:
+    """JSON serializer for `pathlib.Path` objects.
+
+    Converts a `Path` object to its string representation so that it
+    can be serialized by the standard `json` module.
+
+    Args:
+        obj (object): The object to serialize. Expected to be a `Path`.
+
+    Returns:
+        str: The string representation of the `Path`.
+
+    Raises:
+        TypeError: If `obj` is not an instance of `pathlib.Path`.
+    """
+    if isinstance(obj, pathlib.Path):
+        return str(obj)
+    raise TypeError(f"{obj!r} is not JSON serializable")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--model-name", default="resnet50")
+    p.add_argument(
+        "--nodes",
+        # default="stages.0,stages.1,stages.2,stages.3,head.global_pool",
+        default="layer1,layer2,layer3,layer4,global_pool",
+        help="Comma separated list of FX graph node names.",
+    )
+    p.add_argument("--weights-path", type=pathlib.Path, default=None)
+    p.add_argument("--dataset-dir-path", type=pathlib.Path, default="FOOD101")
+    p.add_argument(
+        "--output-dir-path",
+        type=pathlib.Path,
+        default=pathlib.Path("outputs/compute_complexity_measure"),
+    )
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--num-samples", type=int, default=20000)
+    p.add_argument("--batch-size", type=int, default=256)
+    p.add_argument("--ridge-alpha", type=float, default=100)
+    args = p.parse_args()
+
+    device = torch.device(args.device)
+
+    # create output directory
+    now = datetime.now()
+    ts = now.strftime("%Y%m%d_%H%M%S")
+    dir_name = (
+        f"{ts}_model={args.model_name}_weights={str(args.weights_path)}"
+        if args.weights_path
+        else f"{ts}_model={args.model_name}"
+    )
+    output_dir_path = args.output_dir_path / dir_name
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+
+    # dump arguments
+    arguments_output_path = output_dir_path / "args.json"
+    with arguments_output_path.open("w", encoding="utf-8") as f:
+        json.dump(vars(args), f, indent=4, default=path_converter)
+
+    # prepare backbone
+    print(f"Loading model {args.model_name}...")
+    node_keys = args.nodes.split(",")
+    feature_extractor, transform = build_feature_extractor(
+        model_name=args.model_name,
+        node_keys=node_keys,
+        device=device,
+        weights_path=args.weights_path,
+    )
+
+    # prepare datasets
+    import torchvision
+    # if args.dataset_dir_path == pathlib.Path("CIFAR10"):
+    # print("Loading CIFAR10 dataset...")
+    # dataset = torchvision.datasets.CIFAR10(
+    #     root="./data",
+    #     train=False,
+    #     download=True,
+    #     transform=transform
+    # )
+
+    print("Loading FOOD101 dataset...")
+    dataset = torchvision.datasets.Food101(
+        root="./data",
+        split="test",
+        download=True,
+        transform=transform
+    )
+
+    # else:
+    # dataset = ImageFolder(root=args.dataset_dir_path, transform=transform)
+    print("dataset:", dataset)
+    subset = Subset(dataset, torch.randperm(len(dataset))[: args.num_samples])
+    loader = DataLoader(
+        subset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=8,
+        pin_memory=True,
+    )
+    print("transform:", transform)
+    print("len(subset):", len(subset))
+
+    print("Extracting features...")
+    features = extract_features(feature_extractor, loader, args.num_samples, device)
+    features_np = {k: v.numpy() for k, v in features.items() if k not in ("global_pool", "layer4_raw")}
+    z_all = features["global_pool"].numpy() # shape: (num_samples, 2048)
+    penultimate = features["layer4_raw"].numpy()
+    print(f"penultimate.shape: {penultimate.shape}") # shape: (num_samples, 2048, 7, 7)
+
+    # Reshape penultimate features for processing
+    # Original shape: (num_samples, 2048, 7, 7)
+    # Reshape to: (num_samples, 7*7*2048) to iterate over all spatial positions and channels
+    num_samples, channels, height, width = penultimate.shape
+    penultimate_reshaped = penultimate.transpose(0, 2, 3, 1).reshape(num_samples, -1)
+    # penultimate_reshaped shape: (num_samples, 7*7*2048)
+    
+    print(f"penultimate_reshaped.shape: {penultimate_reshaped.shape}")
+    
+    # compute complexity measure K for each feature in penultimate layer
+    complexity_measure_output_path = output_dir_path / "complexity_measure.jsonl"
+    with tqdm(enumerate(penultimate_reshaped.T), total=penultimate_reshaped.shape[1]) as pbar:
+        for i, z in pbar:
+            # Calculate channel, height, and width indices
+            # i = c*h*w + h*w + w
+            pos_idx = i
+            w_idx = pos_idx % width
+            pos_idx = pos_idx // width
+            h_idx = pos_idx % height
+            c_idx = pos_idx // height
+            
+            v_infos = OrderedDict()
+            for k, feat_np in features_np.items():
+                var_z = float(np.var(z, ddof=0))
+                r2 = ridge_regression(feat_np, z)
+                v_infos[k] = VInformation(var_z, r2)
+            complexity_measure_k = ComplexityMeasureK(v_infos)
+            pbar.set_postfix(complexity_measure_k=f"{complexity_measure_k.value:.4f}")
+            print(f"Complexity measure K of z_({c_idx},{h_idx},{w_idx}) = {complexity_measure_k.value:.4f}")
+
+            with complexity_measure_output_path.open("a", encoding="utf-8") as f:
+                out_dict = {
+                    "z_index": i,
+                    "channel": int(c_idx),
+                    "height": int(h_idx),
+                    "width": int(w_idx),
+                    "complexity_measure": asdict(complexity_measure_k),
+                }
+                json.dump(out_dict, f, indent=4)
+                f.write("\n")

--- a/scripts/compute_mean_median.py
+++ b/scripts/compute_mean_median.py
@@ -1,0 +1,66 @@
+import re
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+jsonl_path = Path('outputs/compute_complexity_measure/20250528_053749_model=resnet50_weights=weights/cifar10/pt_imagenet_ft_CIFAR10_resnet50_epoch90.pth/complexity_measure.jsonl')
+
+# Storage dict
+last_values = {}
+
+buffer = ''
+brace_level = 0
+
+with open(jsonl_path, 'r') as f:
+    while True:
+        c = f.read(1)
+        if not c:
+            break
+        if c == '{':
+            if brace_level == 0:
+                buffer = ''  # start new object
+            brace_level += 1
+        if brace_level > 0:
+            buffer += c
+        if c == '}':
+            brace_level -= 1
+            if brace_level == 0:
+                # Completed a JSON object in buffer
+                # Extract z_index
+                idx_match = re.search(r'"z_index"\s*:\s*(\d+)', buffer)
+                if idx_match:
+                    idx = int(idx_match.group(1))
+                    # find all value occurrences
+                    val_matches = list(re.finditer(r'"value"\s*:\s*([-+]?\d*\.\d+|\d+)', buffer))
+                    if val_matches:
+                        last_val_str = val_matches[-1].group(1)
+                        last_val = float(last_val_str)
+                        last_values[idx] = last_val
+                buffer = ''  # reset
+
+# Build list for indices 0..2047
+values_list = [last_values.get(i, float('nan')) for i in range(2048)]
+
+# import csv
+
+# # CSVに書き出し
+# csv_path = "cifar10_2.csv"
+# with open(csv_path, "w", newline="") as f:
+#     writer = csv.writer(f)
+#     # 1行目のヘッダー
+#     # header = ["Value"] + [str(i+1) for i in range(len(values_list))]
+#     # writer.writerow(header)
+#     # 2行目に値を1行で
+#     writer.writerow(["tileDB"] + values_list)
+
+# print(f"やったー！values_listを {csv_path} に保存したよ😆✨")
+
+import numpy as np
+# NaNを除外して計算
+clean_vals = [v for v in values_list if not np.isnan(v)]
+mean_val = np.mean(clean_vals)
+median_val = np.median(clean_vals)
+
+print(f"平均値: {mean_val:.4f}")
+print(f"中央値: {median_val:.4f}")
+
+

--- a/scripts/compute_mean_median_49.py
+++ b/scripts/compute_mean_median_49.py
@@ -1,0 +1,49 @@
+import re
+from pathlib import Path
+import numpy as np
+
+# Path to the JSONL file
+jsonl_path = Path('outputs/compute_complexity_measure/20250528_053749_model=resnet50_weights=weights/cifar10/pt_imagenet_ft_CIFAR10_resnet50_epoch90.pth/complexity_measure.jsonl')
+
+# Storage for complexity measure values
+complexity_values = []
+
+# Read and process the file
+with open(jsonl_path, 'r') as f:
+    buffer = ''
+    brace_level = 0
+    
+    while True:
+        c = f.read(1)
+        if not c:
+            break
+            
+        if c == '{':
+            if brace_level == 0:
+                buffer = ''  # start new object
+            brace_level += 1
+            
+        if brace_level > 0:
+            buffer += c
+            
+        if c == '}':
+            brace_level -= 1
+            if brace_level == 0:
+                # Completed a JSON object in buffer
+                # Extract the complexity_measure.value
+                cm_match = re.search(r'"complexity_measure"\s*:\s*{[^}]*"value"\s*:\s*([-+]?\d*\.\d+|\d+)', buffer)
+                if cm_match:
+                    value = float(cm_match.group(1))
+                    complexity_values.append(value)
+                buffer = ''  # reset
+
+# Calculate statistics
+if complexity_values:
+    mean_val = np.mean(complexity_values)
+    median_val = np.median(complexity_values)
+    
+    print(f"Number of complexity measure values: {len(complexity_values)}")
+    print(f"Mean value: {mean_val:.6f}")
+    print(f"Median value: {median_val:.6f}")
+else:
+    print("No complexity measure values found in the file.")


### PR DESCRIPTION
## Issue URL

NA

## Change overview

This pull request introduces several enhancements and modifications to the feature extraction pipeline, dataset handling, and complexity measure computation scripts. Key changes include updates to the feature extraction logic, the addition of new scripts for complexity measure analysis, and improvements to dataset processing. Below is a categorized summary of the most important changes:

### Feature Extraction Enhancements
* Added logging to indicate whether custom weights or pretrained weights are being loaded in `build_feature_extractor`. Also, explicitly set `num_classes=1000` when loading custom weights. (`mensura/v_info/feature.py`, [mensura/v_info/feature.pyR43-R51](diffhunk://#diff-2d22b6040f2f997067e9bf111d69ed8c65d604cf396d92108afd7027bbb515e5R43-R51))
* Replaced the dynamic data configuration and transformation logic with a fixed `torchvision.transforms.Compose` pipeline for better control over preprocessing. (`mensura/v_info/feature.py`, [mensura/v_info/feature.pyL62-R74](diffhunk://#diff-2d22b6040f2f997067e9bf111d69ed8c65d604cf396d92108afd7027bbb515e5L62-R74))
* Introduced a raw tensor buffer for "layer4" to preserve unflattened features, which is now returned alongside the processed buffers. (`mensura/v_info/feature.py`, [[1]](diffhunk://#diff-2d22b6040f2f997067e9bf111d69ed8c65d604cf396d92108afd7027bbb515e5R155-R159) [[2]](diffhunk://#diff-2d22b6040f2f997067e9bf111d69ed8c65d604cf396d92108afd7027bbb515e5R179-R185)

### Dataset and Node Key Updates
* Updated the default node keys for feature extraction from `"stages.*"` to `"layer*"` to align with a new model structure. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyL48-R49](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8L48-R49))
* Added debug logging to print the dataset structure and ensure proper loading of datasets. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyR94-R104](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8R94-R104))

### Complexity Measure Computation
* Modified the complexity measure computation to exclude "layer4_raw" and "global_pool" from certain calculations. Added experimental code (commented out) for dynamic coefficient computation based on spatial correlations in the penultimate layer. (`scripts/compute_complexity_measure.py`, [scripts/compute_complexity_measure.pyL107-R219](diffhunk://#diff-ac9ae4a58869dcc1502d391a13cec56c2ed8ce54b41b40efc76cd8db6cef11d8L107-R219))
* Introduced a new script, `compute_complexity_measure_49.py`, to compute complexity measures for individual spatial positions in the penultimate layer, with reshaping logic and detailed logging for debugging.

### Statistical Analysis Scripts
* Added `compute_mean_median.py` to extract and analyze the last complexity measure values from a JSONL file, including mean and median calculations.
* Added `compute_mean_median_49.py`, a streamlined version of the above script, focused on extracting and summarizing complexity measure values with fewer dependencies.

## How to test
```
uv run scripts/compute_complexity_measure.py
```

## Note for reviewers
If you want to perform calculations using dynamic coefficients, remove the comment out lines from "# 空間相関ρ̂を推定して動的係数aを計算" to above "#######実験中".


_49がAVGpoolをしない場合のコードです。そのまま実行してください。

このプルリクエストはマージしません。